### PR TITLE
解决构建时的代码混淆需求

### DIFF
--- a/bin/flutter_walle_plugin.dart
+++ b/bin/flutter_walle_plugin.dart
@@ -5,35 +5,40 @@ import 'package:args/src/usage.dart';
 import 'package:args/args.dart';
 
 void main(args) {
-  var parser = new ArgParser()..addCommand('setChannel')..addCommand('setInfo')..addCommand('getInfo');
+  var parser = new ArgParser.allowAnything();
   //  BuildApk buildApk = BuildApk()..build();
   var results = parser.parse(args);
 
-  if (results.command?.name == null) {
+  if (results.arguments.length == 0) {
     print(Usage([
       'setChannel        编译apk并写入渠道号 flutter pub run flutter_walle_plugin setChannel flutter build apk',
       'setInfo           编译apk并写入渠道信息 flutter pub run flutter_walle_plugin setInfo flutter build apk',
       'getInfo           查看指定apk文件渠道信息 flutter pub run flutter_walle_plugin getInfo /Users/hjc1/Documents/flutter/money_answer/channelApks/app-release_huawei.apk'
     ], lineLength: 5)
         .generate());
-  } else {
-    var build = BuildApk();
-    List<String> list = [...results.command.arguments];
-    list.remove('flutter');
-    if (results.command?.name == 'setChannel') {
-      print(results.command.arguments);
-      build.build(list);
-    } else if (results.command?.name == 'setInfo') {
-      build.build(list, isSetInfo: true);
-    } else if (results.command?.name == 'getInfo') {
-      if (results.command?.arguments?.first == null) {
-        throw ArgumentError('没有apk文件路径，需要完整路径');
-      }
-      build.getApkInfo(results.command?.arguments?.first);
-    } else {
-      throw ArgumentError('没有选择命令');
-    }
+    return;
   }
+
+  final command = results.arguments[0];
+  final arguments = results.arguments.sublist(1);
+  print('command: $command, arguments: $arguments');
+
+  var build = BuildApk();
+  List<String> list = [...arguments];
+  list.remove('flutter');
+  if (command == 'setChannel') {
+    build.build(list);
+  } else if (command == 'setInfo') {
+    build.build(list, isSetInfo: true);
+  } else if (command == 'getInfo') {
+    if (arguments.first == null) {
+      throw ArgumentError('没有apk文件路径，需要完整路径');
+    }
+    build.getApkInfo(arguments.first);
+  } else {
+    throw ArgumentError('没有选择命令');
+  }
+
 }
 
 class BuildApk {


### PR DESCRIPTION
首先非常感谢开发这个库，以前我们一直在使用美团的Walle，现在flutter上有这个库真的很方便。

但我们使用过程中遇到一个问题，当需要代码混淆时（dart部分），要在`flutter build apk`后追加参数（参考 [官方文档](https://flutter.dev/docs/deployment/obfuscate)），整条指令如下：

```sh
flutter pub run flutter_walle_plugin setChannel flutter build apk --obfuscate --split-debug-info=myapp/version
```

按照本项目使用的`args`库逻辑，会将以`--`开头的参数（比如`--obfuscate`）解析为父指令集的options，而非传递给子指令集，因此修改了构造器为`ArgParser.allowAnything()`并自行解析command，以确保子指令集参数能被正确获取。

希望能接受此PR并发布新版本，非常感谢。